### PR TITLE
Fix docker run in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
                    docker kill "$APP_NAME"
                    docker rm "$APP_NAME"
                 fi
-                docker run -d -p 8080:8080 --name "$APP_NAME $DOCKER_HUB_ACCOUNT/$APP_NAME:$BUILD_NUMBER"
+                docker run -d -p 8080:8080 --name "$APP_NAME" "$DOCKER_HUB_ACCOUNT/$APP_NAME:$BUILD_NUMBER"
                 docker ps
                 '''
             }


### PR DESCRIPTION
Previously, we were quoting all of the variables together, which caused
docker run to fail. Now the issues has been resolved.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>