### PR TITLE
Add a more robust gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,28 @@
+# Ignonnre node files
 node_modules
-.DS_Store
+
+# Ignore Vim files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+Session.vim
+.netrwhist
+*~
+tags
+
+# Ignore macOS files
+*.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk


### PR DESCRIPTION
Git has now been configured to ignore vim and macOS files.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>